### PR TITLE
Update pyproject.toml deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ authors = ["OpenCRS"]
 version = "0.1.0"
 
 [tool.poetry.dependencies]
-python = "^3.12"
+python = "^3.10"
 angr = "^9.2.24"
 docker = "^6.1.2"
 click = "^8.1.3"
@@ -24,6 +24,8 @@ tracer = { git = "https://github.com/angr/tracer.git" }
 setuptools = "^65.5.0"
 keystone = "^22.0.0"
 keystone-engine = "^0.9.2"
+commons = {path = "../commons"}
+zeratool_lib = {path = "../zeratool_lib"}
 
 [tool.poetry.dev-dependencies]
 black = "^22.6.0"


### PR DESCRIPTION
Using python 3.12 will result into an error because distutils is no longer supported. Downgrading to python 3.10 will solve this issue.